### PR TITLE
github/workflows: add workflow_call to shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches: [main]
+    workflow_call:
+
 
 jobs:
   shellcheck:
@@ -13,5 +15,5 @@ jobs:
         - uses: actions/checkout@v3
         - name: ShellCheck
           uses: ludeeus/action-shellcheck@2.0.0
-          env: 
+          env:
             SHELLCHECK_OPTS: -e SC2086 -e SC2154


### PR DESCRIPTION
This will allow the shellcheck workflow to be triggered by other workflows. This is useful for the weekly shellcheck workflow that will be triggered by the weekly workflow.